### PR TITLE
Fix comma causing curl error

### DIFF
--- a/plugin/vim_llama.vim
+++ b/plugin/vim_llama.vim
@@ -9,7 +9,7 @@ function! TestOllamaConnection()
     echoerr "ERROR: Ping not found!"
     return 1
   endif
-  let l:output = system("curl --connect-timeout 0,2 -sL -w \"%{http_code}\" http://" . l:ip_port)
+  let l:output = system("curl --connect-timeout 0.2 -sL -w \"%{http_code}\" http://" . l:ip_port)
   if l:output !~# '200$'
     echomsg "Testing if ollama is reachable at " . l:ip_port
     echoerr "ERROR: IP/Port not reachable!"


### PR DESCRIPTION
```
curl --connect-timeout 0,2 -sL -w \"%{http_code}\" http://
```
from `curl` manpage:
```
       --connect-timeout <seconds>
              ...
              This option accepts decimal values. The decimal value needs to be  provided
              using  a  dot  (.)  as decimal separator - not the local version even if it
              might be using another separator.
```

```
Error detected while processing ~/.vim/plugged/vim-llama/plugin/vim_llama.vim[48]..function TestOllamaConnection:
line   12:
ERROR: IP/Port not reachable!
```